### PR TITLE
chore: fix CHANGELOG.md reference in mix.exs and update README version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ by adding `off_broadway_splunk` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:off_broadway_splunk, "~> 2.0"}
+    {:off_broadway_splunk, "~> 3.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule OffBroadway.Splunk.MixProject do
         source_url: @source_url,
         extras: [
           "README.md",
-          "Changelog.md",
+          "CHANGELOG.md",
           "LICENSE"
         ]
       ],


### PR DESCRIPTION
## Summary

- `mix.exs` docs extras still referenced `Changelog.md` (old filename) after the file was renamed to `CHANGELOG.md`, causing the hex publish for v3.0.0 to fail
- README install example updated from `~> 2.0` to `~> 3.0`

## Notes

Uses `chore:` prefix so release-please does not open a new release PR or bump the version beyond 3.0.0.