### PR TITLE
feat: retry transient 401/403 auth errors with exponential backoff

### DIFF
--- a/lib/off_broadway/splunk/options.ex
+++ b/lib/off_broadway/splunk/options.ex
@@ -45,6 +45,16 @@ defmodule OffBroadway.Splunk.Options do
         """,
         default: :infinity
       ],
+      max_auth_retries: [
+        type: :pos_integer,
+        doc: """
+        The maximum number of consecutive 401/403 auth errors before the producer
+        stops. This allows the producer to survive transient auth failures during
+        Splunk rolling updates or token rotation windows. Set to 1 to stop
+        immediately on the first auth error (previous behavior).
+        """,
+        default: 3
+      ],
       on_success: [
         type: :atom,
         doc: """
@@ -92,7 +102,9 @@ defmodule OffBroadway.Splunk.Options do
             `max_events` messages from the Splunk API.
             """,
             type: {:custom, __MODULE__, :type_nil_or_pos_integer, [[{:name, :max_events}]]}
-          ]
+          ],
+          # For test
+          auth_error_agent: [type: :pid, doc: false]
         ],
         doc: """
         A set of config options that overrides the default config for the `splunk_client`

--- a/lib/off_broadway/splunk/producer.ex
+++ b/lib/off_broadway/splunk/producer.ex
@@ -130,11 +130,27 @@ defmodule OffBroadway.Splunk.Producer do
 
     * `[:off_broadway_splunk, :receive_messages, :error]` - Dispatched when fetching events
       for a job fails, either due to a non-200 HTTP response or a network error. A 401 or 403
-      status will also cause the producer to stop.
+      status will be retried up to `:max_auth_retries` times before stopping the producer
+      (see the `:max_auth_retries` option).
 
       * measurement: `%{time: System.system_time}`
       * metadata (HTTP error): `%{name: string, sid: string, demand: integer, status: integer}`
       * metadata (network error): `%{name: string, sid: string, demand: integer, reason: term}`
+
+    * `[:off_broadway_splunk, :auth, :error]` - Dispatched on each 401/403 auth error,
+      whether it results in a retry or a producer stop.
+
+      * measurement: `%{time: System.system_time}`
+      * metadata:
+
+        ```
+        %{
+          name: string,
+          status: integer,
+          auth_error_count: integer,
+          max_auth_retries: integer
+        }
+        ```
   """
 
   use GenStage
@@ -143,6 +159,8 @@ defmodule OffBroadway.Splunk.Producer do
   alias OffBroadway.Splunk.{Job, Options}
 
   @behaviour Producer
+
+  @max_backoff_interval 30_000
 
   @impl true
   def init(opts) do
@@ -172,7 +190,9 @@ defmodule OffBroadway.Splunk.Producer do
        queue: :queue.new(),
        splunk_client: {client, client_opts},
        broadway: opts[:broadway][:name],
-       shutdown_timeout: opts[:shutdown_timeout]
+       shutdown_timeout: opts[:shutdown_timeout],
+       auth_error_count: 0,
+       max_auth_retries: opts[:max_auth_retries]
      }}
   end
 
@@ -270,6 +290,7 @@ defmodule OffBroadway.Splunk.Producer do
     case receive_jobs_from_splunk(state) do
       {:ok, _} = response ->
         new_state = update_queue_from_response(response, state)
+        new_state = %{new_state | auth_error_count: 0}
 
         case new_state do
           %{current_job: nil, queue: {[], []}} ->
@@ -288,7 +309,9 @@ defmodule OffBroadway.Splunk.Producer do
         end
 
       {:error, {:http_error, status}} when status in [401, 403] ->
-        {:stop, :unauthorized, state}
+        handle_auth_error(state, status, :refetch_timer, fn _s, interval ->
+          schedule_receive_jobs(interval)
+        end)
 
       {:error, _reason} ->
         {:noreply, [], %{state | refetch_timer: schedule_receive_jobs(state.refetch_interval)}}
@@ -353,10 +376,13 @@ defmodule OffBroadway.Splunk.Producer do
     case receive_jobs_from_splunk(state) do
       {:ok, _} = response ->
         new_state = update_queue_from_response(response, state)
+        new_state = %{new_state | auth_error_count: 0}
         {:noreply, [], %{new_state | receive_timer: schedule_receive_messages(0)}}
 
       {:error, {:http_error, status}} when status in [401, 403] ->
-        {:stop, :unauthorized, state}
+        handle_auth_error(state, status, :receive_timer, fn _s, interval ->
+          schedule_receive_messages(interval)
+        end)
 
       {:error, _reason} ->
         {:noreply, [], %{state | receive_timer: schedule_receive_messages(state.receive_interval)}}
@@ -407,6 +433,49 @@ defmodule OffBroadway.Splunk.Producer do
 
   defp handle_receive_messages(%{receive_timer: nil} = state) do
     {:noreply, [], %{state | receive_timer: schedule_receive_messages(state.receive_interval)}}
+  end
+
+  @spec handle_auth_error(
+          state :: map(),
+          status :: integer(),
+          timer_key :: atom(),
+          reschedule_fn :: (map(), non_neg_integer() -> reference())
+        ) ::
+          {:noreply, [], map()} | {:stop, :unauthorized, map()}
+  defp handle_auth_error(state, status, timer_key, reschedule_fn) do
+    new_count = state.auth_error_count + 1
+
+    :telemetry.execute(
+      [:off_broadway_splunk, :auth, :error],
+      %{time: System.system_time()},
+      %{name: state.name, status: status, auth_error_count: new_count, max_auth_retries: state.max_auth_retries}
+    )
+
+    if new_count > state.max_auth_retries do
+      {:stop, :unauthorized, %{state | auth_error_count: new_count}}
+    else
+      base =
+        case timer_key do
+          :refetch_timer -> state.refetch_interval
+          :receive_timer -> state.receive_interval
+        end
+
+      interval = backoff_interval(base, new_count)
+
+      new_state =
+        state
+        |> Map.put(:auth_error_count, new_count)
+        |> Map.put(timer_key, reschedule_fn.(state, interval))
+
+      {:noreply, [], new_state}
+    end
+  end
+
+  @doc false
+  @spec backoff_interval(base :: non_neg_integer(), error_count :: pos_integer()) :: non_neg_integer()
+  def backoff_interval(base, error_count) do
+    uncapped = Bitwise.bsl(base, error_count - 1)
+    min(uncapped, max(base, @max_backoff_interval))
   end
 
   @spec receive_jobs_from_splunk(state :: map()) :: {:ok, Tesla.Env.t()} | {:error, any()}
@@ -508,18 +577,35 @@ defmodule OffBroadway.Splunk.Producer do
             end
           )
 
-        case result do
-          {:error, {:http_error, status}} when status in [401, 403] ->
-            {:stop, :unauthorized, state}
-
-          {:error, reason} ->
-            {:error, reason, state}
-
-          messages ->
-            {:ok, messages, state}
-        end
+        handle_receive_messages_result(result, state)
     end
   end
+
+  @spec handle_receive_messages_result(result :: any(), state :: map()) ::
+          {:ok, messages :: list(), state :: map()}
+          | {:error, reason :: any(), state :: map()}
+          | {:stop, reason :: any(), state :: map()}
+  defp handle_receive_messages_result({:error, {:http_error, status}}, state)
+       when status in [401, 403] do
+    new_count = state.auth_error_count + 1
+
+    :telemetry.execute(
+      [:off_broadway_splunk, :auth, :error],
+      %{time: System.system_time()},
+      %{name: state.name, status: status, auth_error_count: new_count, max_auth_retries: state.max_auth_retries}
+    )
+
+    if new_count > state.max_auth_retries do
+      {:stop, :unauthorized, %{state | auth_error_count: new_count}}
+    else
+      {:error, {:http_error, status}, %{state | auth_error_count: new_count}}
+    end
+  end
+
+  defp handle_receive_messages_result({:error, reason}, state), do: {:error, reason, state}
+
+  defp handle_receive_messages_result(messages, state),
+    do: {:ok, messages, %{state | auth_error_count: 0}}
 
   @spec update_queue_from_response(
           response :: {:ok, Tesla.Env.t()},

--- a/test/off_broadway/splunk/producer_test.exs
+++ b/test/off_broadway/splunk/producer_test.exs
@@ -238,6 +238,61 @@ defmodule OffBroadway.Splunk.ProducerTest do
     def receive_messages(_sid, _demand, _opts), do: {:error, {:http_error, 403}}
   end
 
+  defmodule TransientAuth401StatusClient do
+    @behaviour OffBroadway.Splunk.Client
+
+    @impl true
+    def init(opts) do
+      {:ok, Keyword.take(opts, [:test_pid, :message_server]) |> Keyword.merge(opts[:config])}
+    end
+
+    @impl true
+    def receive_status(_name, opts) do
+      send(opts[:test_pid], :receive_status_called)
+
+      case Agent.get_and_update(opts[:auth_error_agent], fn count ->
+             if count > 0, do: {:error, count - 1}, else: {:ok, count}
+           end) do
+        :error ->
+          {:ok, %{status: 401, body: %{}}}
+
+        :ok ->
+          {:ok,
+           %{
+             status: 200,
+             body: %{
+               "entry" => [
+                 %{
+                   "name" => "test-job",
+                   "published" => "2022-06-28T15:00:02.000+02:00",
+                   "content" => %{"isDone" => true, "isScheduled" => true, "isZombie" => false}
+                 }
+               ]
+             }
+           }}
+      end
+    end
+
+    @impl true
+    def receive_messages(_sid, demand, opts) do
+      messages = MessageServer.take_messages(opts[:message_server], demand)
+      send(opts[:test_pid], {:messages_received, length(messages)})
+
+      result =
+        for msg <- messages do
+          metadata = %{custom: "custom-data"}
+
+          %Broadway.Message{
+            data: msg,
+            metadata: metadata,
+            acknowledger: {Broadway.NoopAcknowledger, nil, nil}
+          }
+        end
+
+      {:ok, result}
+    end
+  end
+
   defp prepare_for_start_module_opts(module_opts) do
     {:ok, message_server} = MessageServer.start_link()
     {:ok, pid} = start_broadway(message_server)
@@ -425,6 +480,84 @@ defmodule OffBroadway.Splunk.ProducerTest do
           )
         end
       )
+    end
+
+    test "when :max_auth_retries is a negative integer" do
+      assert_raise(
+        ArgumentError,
+        ~r/invalid value for :max_auth_retries option/,
+        fn ->
+          prepare_for_start_module_opts(
+            name: "My fine report",
+            max_auth_retries: -1
+          )
+        end
+      )
+    end
+
+    test "when :max_auth_retries is zero" do
+      assert_raise(
+        ArgumentError,
+        ~r/invalid value for :max_auth_retries option/,
+        fn ->
+          prepare_for_start_module_opts(
+            name: "My fine report",
+            max_auth_retries: 0
+          )
+        end
+      )
+    end
+
+    test ":max_auth_retries defaults to 3" do
+      assert {[],
+              [
+                producer: [
+                  module: {Producer, result_module_opts},
+                  concurrency: 1
+                ]
+              ]} = prepare_for_start_module_opts(name: "My fine report")
+
+      assert result_module_opts[:max_auth_retries] == 3
+    end
+
+    test ":max_auth_retries accepts a positive integer" do
+      assert {[],
+              [
+                producer: [
+                  module: {Producer, result_module_opts},
+                  concurrency: 1
+                ]
+              ]} =
+               prepare_for_start_module_opts(
+                 name: "My fine report",
+                 max_auth_retries: 10
+               )
+
+      assert result_module_opts[:max_auth_retries] == 10
+    end
+  end
+
+  describe "backoff_interval/2" do
+    test "doubles the base interval for each consecutive error" do
+      assert Producer.backoff_interval(5_000, 1) == 5_000
+      assert Producer.backoff_interval(5_000, 2) == 10_000
+      assert Producer.backoff_interval(5_000, 3) == 20_000
+    end
+
+    test "caps at @max_backoff_interval (30s) when base is smaller" do
+      assert Producer.backoff_interval(5_000, 4) == 30_000
+      assert Producer.backoff_interval(5_000, 10) == 30_000
+    end
+
+    test "caps at base interval when base exceeds @max_backoff_interval" do
+      assert Producer.backoff_interval(60_000, 1) == 60_000
+      assert Producer.backoff_interval(60_000, 2) == 60_000
+      assert Producer.backoff_interval(60_000, 3) == 60_000
+    end
+
+    test "returns 0 when base is 0" do
+      assert Producer.backoff_interval(0, 1) == 0
+      assert Producer.backoff_interval(0, 3) == 0
     end
   end
 
@@ -729,6 +862,93 @@ defmodule OffBroadway.Splunk.ProducerTest do
       assert_receive {:telemetry_event, [:off_broadway_splunk, :producer, :stop], %{time: _},
                       %{name: "My fine report", reason: :unauthorized}},
                      5000
+    end
+
+    test "retries on transient 401 from receive_jobs and recovers" do
+      {:ok, auth_error_agent} = Agent.start_link(fn -> 2 end)
+      {:ok, message_server} = MessageServer.start_link()
+
+      {:ok, pid} =
+        start_broadway(message_server, new_unique_name(),
+          splunk_client: TransientAuth401StatusClient,
+          max_auth_retries: 3,
+          config: [auth_error_agent: auth_error_agent]
+        )
+
+      MessageServer.push_messages(message_server, [1, 2])
+
+      assert_receive {:messages_received, _}, 5000
+      assert_receive {:message_handled, _, _}, 5000
+
+      stop_broadway(pid)
+    end
+
+    test "stops producer after exceeding max_auth_retries from receive_jobs" do
+      Process.flag(:trap_exit, true)
+      on_exit(fn -> Process.flag(:trap_exit, false) end)
+
+      {:ok, auth_error_agent} = Agent.start_link(fn -> 100 end)
+      {:ok, message_server} = MessageServer.start_link()
+
+      broadway_name = new_unique_name()
+
+      {:ok, pid} =
+        start_broadway(message_server, broadway_name,
+          splunk_client: TransientAuth401StatusClient,
+          max_auth_retries: 3,
+          config: [auth_error_agent: auth_error_agent]
+        )
+
+      ref = Process.monitor(pid)
+      assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, 5000
+    end
+
+    test "emits [:off_broadway_splunk, :auth, :error] telemetry on each retry" do
+      self = self()
+
+      :ok =
+        :telemetry.attach(
+          "auth_error_retry_test",
+          [:off_broadway_splunk, :auth, :error],
+          fn name, measurements, metadata, _ ->
+            send(self, {:telemetry_event, name, measurements, metadata})
+          end,
+          nil
+        )
+
+      on_exit(fn -> :telemetry.detach("auth_error_retry_test") end)
+
+      Process.flag(:trap_exit, true)
+      on_exit(fn -> Process.flag(:trap_exit, false) end)
+
+      {:ok, message_server} = MessageServer.start_link()
+
+      {:ok, _pid} =
+        start_broadway(message_server, new_unique_name(),
+          splunk_client: Http401StatusSplunkClient,
+          max_auth_retries: 3
+        )
+
+      assert_receive {:telemetry_event, [:off_broadway_splunk, :auth, :error], %{time: _},
+                      %{name: "My fine report", status: 401, auth_error_count: 1, max_auth_retries: 3}},
+                     5000
+    end
+
+    test "max_auth_retries: 1 stops immediately on first auth error (legacy behavior)" do
+      Process.flag(:trap_exit, true)
+      on_exit(fn -> Process.flag(:trap_exit, false) end)
+
+      broadway_name = new_unique_name()
+      {:ok, message_server} = MessageServer.start_link()
+
+      {:ok, pid} =
+        start_broadway(message_server, broadway_name,
+          splunk_client: Http401StatusSplunkClient,
+          max_auth_retries: 1
+        )
+
+      ref = Process.monitor(pid)
+      assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, 5000
     end
   end
 


### PR DESCRIPTION
## Summary

- Add configurable `max_auth_retries` option (default 3) so the producer retries transient 401/403 auth errors during Splunk rolling updates instead of immediately stopping the pipeline
- Retries use exponential backoff (base interval * 2^n) capped at 30s or the base interval, whichever is larger
- Emit `[:off_broadway_splunk, :auth, :error]` telemetry event on each auth error for observability
- Fully backwards compatible: existing producers get the new retry behavior by default; set `max_auth_retries: 1` to restore the previous immediate-stop behavior

Closes #19

## Test plan

- [x] 4 validation tests for `max_auth_retries` option (negative, zero, default, positive)
- [x] 4 unit tests for `backoff_interval/2` (doubling, cap when base < 30s, cap when base > 30s, zero base)
- [x] Transient 401 recovery test (2 failures then success)
- [x] Exceeding max retries stops the producer
- [x] Legacy behavior test (`max_auth_retries: 1` stops immediately)
- [x] Telemetry event emission test
- [x] Existing 401/403 tests still pass unchanged
- [x] Full suite: 45 tests, 0 failures
- [x] Dialyzer, Credo, format checks pass